### PR TITLE
Relax method_source version

### DIFF
--- a/active_mappers.gemspec
+++ b/active_mappers.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
   s.add_runtime_dependency('activesupport', ['>= 4.2'])
-  s.add_runtime_dependency('method_source', ['~> 0.9.2'])
+  s.add_runtime_dependency('method_source', ['>= 0.9.2'])
   s.add_runtime_dependency('mocha', ['>= 1.8.0'])
   s.add_runtime_dependency('ruby2ruby', ['> 2.4.0'])
   s.add_runtime_dependency('ruby_parser', ['~> 3.1'])


### PR DESCRIPTION
I can't upgrade pry because the latest version require method_source 1.0